### PR TITLE
ndk-build: Add manifest attributes `android:extractNativeLibs`, `android:usesCleartextTraffic` and `android:alwaysRetainTaskState`

### DIFF
--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -151,6 +151,12 @@ icon = "@mipmap/ic_launcher"
 # Defaults to the compiled artifact's name.
 label = "Application Name"
 
+# See https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs
+extract_native_libs = true
+
+# See https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic
+uses_cleartext_traffic = true
+
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #
 # Note: there can be several .meta_data entries.
@@ -191,6 +197,9 @@ exported = true
 #
 # Defaults to true on Android >= 24, no effect on earlier API levels
 resizeable_activity = false
+
+# See https://developer.android.com/guide/topics/manifest/activity-element#always
+always_retain_task_state = true
 
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Add `android:extractNativeLibs`, `android:usesCleartextTraffic`, attributes to the manifest's `Application` element, and `android:alwaysRetainTaskState` to the `Activity` element.
+- Add `android:extractNativeLibs`, `android:usesCleartextTraffic`, attributes to the manifest's `Application` element, and `android:alwaysRetainTaskState` to the `Activity` element. ([#15](https://github.com/rust-mobile/cargo-apk/pull/15))
 
 # 0.9.0 (2022-11-23)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `android:extractNativeLibs`, `android:usesCleartextTraffic`, attributes to the manifest's `Application` element, and `android:alwaysRetainTaskState` to the `Activity` element.
+
 # 0.9.0 (2022-11-23)
 
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -77,6 +77,10 @@ pub struct Application {
     #[serde(rename(serialize = "android:label"))]
     #[serde(default)]
     pub label: String,
+    #[serde(rename(serialize = "android:extractNativeLibs"))]
+    pub extract_native_libs: Option<bool>,
+    #[serde(rename(serialize = "android:usesCleartextTraffic"))]
+    pub uses_cleartext_traffic: Option<bool>,
 
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]
@@ -104,6 +108,8 @@ pub struct Activity {
     pub exported: Option<bool>,
     #[serde(rename(serialize = "android:resizeableActivity"))]
     pub resizeable_activity: Option<bool>,
+    #[serde(rename(serialize = "android:alwaysRetainTaskState"))]
+    pub always_retain_task_state: Option<bool>,
 
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]
@@ -124,6 +130,7 @@ impl Default for Activity {
             orientation: None,
             exported: None,
             resizeable_activity: None,
+            always_retain_task_state: None,
             meta_data: Default::default(),
             intent_filter: Default::default(),
         }


### PR DESCRIPTION
This PR adds support for manifest attributes:
`Application` element:
- `android:extractNativeLibs`
- `android:usesCleartextTraffic`

`Activity` element:
- `android:alwaysRetainTaskState`