### PR TITLE
cargo-apk: Support new `Artifact` format for `[lib]`, `[[bin]]` and `[[example]]` renames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
     "examples",
     "cargo-apk",
 ]
+
+[patch.crates-io]
+# Unreleased, including https://github.com/rust-mobile/cargo-subcommand/pull/17
+cargo-subcommand = { git = "https://github.com/rust-mobile/cargo-subcommand.git", rev = "281b281" }

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -5,11 +5,13 @@ Tool for creating Android packages.
 ## Installation
 
 From crates.io:
+
 ```console
 $ cargo install cargo-apk
 ```
 
 From source:
+
 ```console
 $ cargo install --path .
 ```
@@ -80,7 +82,7 @@ runtime_libs = "path/to/libs_folder"
 # and keystore password respectively. The profile portion follows the same rules
 # as `<cfg>`, it is the uppercased profile name with `-` replaced with `_`.
 #
-# If present they take precedence over the signing information in the manifest. 
+# If present they take precedence over the signing information in the manifest.
 [package.metadata.android.signing.<profile>]
 path = "relative/or/absolute/path/to/my.keystore"
 keystore_password = "android"


### PR DESCRIPTION
Fixes: https://github.com/rust-mobile/cargo-apk/issues/7

https://github.com/rust-mobile/cargo-subcommand/pull/17
