### PR TITLE
Don't copy permission bits when copying files

### DIFF
--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -128,7 +128,12 @@ impl<'a> UnalignedApk<'a> {
 
         match self.config.strip {
             StripConfig::Default => {
-                std::fs::copy(path, out)?;
+                // This is not std::fs::copy because don't want to copy permission bits
+                // For example, when copying from nix store
+                std::io::copy(
+                    &mut std::io::BufReader::new(std::fs::File::open(path)?),
+                    &mut std::io::BufWriter::new(std::fs::File::create(out)?),
+                )?;
             }
             StripConfig::Strip | StripConfig::Split => {
                 let obj_copy = self.config.ndk.toolchain_bin("objcopy", target)?;


### PR DESCRIPTION
I was using NixOS and copying files from nix store resulted in them not having write permissions, so only the first build could succeed, and later ones would fail to overwrite the file. This fix has solved the issue for me.