### PR TITLE
apk: Use `rustc --crate-type=cdylib` to always force a lib to be compiled

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,10 @@ jobs:
         run: cargo install --path cargo-apk
 
       - name: Cargo apk build for target ${{ matrix.rust-target }}
-        run: cargo apk build -p examples --target ${{ matrix.rust-target }} --examples
+        run: |
+          cargo apk build -p examples --target ${{ matrix.rust-target }} --example hello_world
+          cargo apk build -p examples --target ${{ matrix.rust-target }} --example jni_audio
+          cargo apk build -p examples --target ${{ matrix.rust-target }} --example looper
 
       - uses: actions/upload-artifact@v2
         # Only need this for CI, unless users are interested in downloading

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -228,7 +228,8 @@ impl<'a> ApkBuilder<'a> {
                 self.min_sdk_version(),
                 self.cmd.target_dir(),
             )?;
-            cargo.arg("build");
+            cargo.arg("rustc");
+            cargo.arg("--crate-type=cdylib");
             if self.cmd.target().is_none() {
                 cargo.arg("--target").arg(triple);
             }


### PR DESCRIPTION
This automatically turns `crate-type = ["*lib"]` and `[lib]` targets into a `cdylib`, and otherwise errors appropriately when encountering a binary instead of succeeding the build and having `cargo-apk` later complain when `target/aarch64-linux-android/debug/lib<yourpacakge>.so` is not found.
