### PR TITLE
ndk-build: Enable building from `android` host

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Enable building from `android` host ([#29](https://github.com/rust-mobile/cargo-apk/pull/29))
+
 # 0.9.0 (2022-11-23)
 
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -239,12 +239,16 @@ impl Ndk {
             "darwin"
         } else if host_contains("windows") {
             "windows"
+        } else if host_contains("android") {
+            "android"
         } else if cfg!(target_os = "linux") {
             "linux"
         } else if cfg!(target_os = "macos") {
             "darwin"
         } else if cfg!(target_os = "windows") {
             "windows"
+        } else if cfg!(target_os = "android") {
+            "android"
         } else {
             return match host_os {
                 Some(host_os) => Err(NdkError::UnsupportedHost(host_os)),


### PR DESCRIPTION
fix running from termux
