### PR TITLE
ndk-build: Use `uid` to limit `logcat` to the current application

### DIFF
--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -313,7 +313,8 @@ impl<'a> ApkBuilder<'a> {
         let apk = self.build(artifact)?;
         apk.reverse_port_forwarding(self.device_serial.as_deref())?;
         apk.install(self.device_serial.as_deref())?;
-        let pid = apk.start(self.device_serial.as_deref())?;
+        apk.start(self.device_serial.as_deref())?;
+        let uid = apk.uidof(self.device_serial.as_deref())?;
 
         if !no_logcat {
             self.ndk
@@ -321,8 +322,8 @@ impl<'a> ApkBuilder<'a> {
                 .arg("logcat")
                 .arg("-v")
                 .arg("color")
-                .arg("--pid")
-                .arg(pid.to_string())
+                .arg("--uid")
+                .arg(uid.to_string())
                 .status()?;
         }
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - Add `android:extractNativeLibs`, `android:usesCleartextTraffic` attributes to the manifest's `Application` element, and `android:alwaysRetainTaskState` to the `Activity` element. ([#15](https://github.com/rust-mobile/cargo-apk/pull/15))
-- Enable building from `android` host ([#29](https://github.com/rust-mobile/cargo-apk/pull/29))
+- Enable building from `android` host. ([#29](https://github.com/rust-mobile/cargo-apk/pull/29))
+- Use app `uid` instead of `pid` to limit `logcat` output to the current app. ([#33](https://github.com/rust-mobile/cargo-apk/pull/33))
 
 # 0.9.0 (2022-11-23)
 

--- a/ndk-build/src/error.rs
+++ b/ndk-build/src/error.rs
@@ -48,6 +48,10 @@ pub enum NdkError {
     CmdFailed(Command),
     #[error(transparent)]
     Serialize(#[from] quick_xml::de::DeError),
-    #[error("String `{1}` is not a PID")]
-    NotAPid(#[source] ParseIntError, String),
+    #[error("String `{1}` is not a UID")]
+    NotAUid(#[source] ParseIntError, String),
+    #[error("Could not find `package:{package}` in output `{output}`")]
+    PackageNotInOutput { package: String, output: String },
+    #[error("Could not find `uid:` in output `{0}`")]
+    UidNotInOutput(String),
 }


### PR DESCRIPTION
Fixes #10

This is a port of:
https://github.com/rust-mobile/xbuild/pull/131
https://github.com/rust-mobile/xbuild/pull/135

Having never really understood how Android Studio does it, I just stumbled upon this very new [stackoverflow answer] that has a rather beatiful solution to the current problems with `pidof`, without drawbacks.  Pidof has always been flaky as it relies on the app to be running, which may either take some time or never happen if the app crashed before `pidof` is first run.  This results in silly workarounds such as loops that induce extra delay and need to have an upper bound. And this `pid` changes every time the app is restarted, making it a tedious process that also doesn't react to manual app restarts on the device.  Retrieving the `uid` via `pm list packages -U` on the other hand, and passing that to `logcat --uid` has the following advantages:

- Always available immediately after the app has been installed, no need to check it in a loop (no extra delay);
- Doesn't change after the app is (re!)installed, unless the user fully deletes and installs the app again;
- Is resilient against app crashes because of that, and allows the user to see any error/crash related messages straight away;
- Still includes logs printed by other system components that run or are invoked within an app, as before.

The only downside is that `pm list package` possibly returns multiple packages if there is a substring match; for this reason the code searches for an explicit match in the output.

[stackoverflow answer]: https://stackoverflow.com/a/76551835
