### PR TITLE
Add support for optional `package.version` in `Cargo.toml`.

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Support for optional `package.version` field in `Cargo.toml`. ([#56](https://github.com/rust-mobile/cargo-apk/pull/56))
+
 # 0.10.0 (2023-11-30)
 
 - Bump MSRV to 1.70 to reflect dependency updates.

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -49,8 +49,8 @@ impl<'a> ApkBuilder<'a> {
             .join("apk");
 
         let package_version = match &manifest.version {
-            Inheritable::Value(v) => v.clone(),
-            Inheritable::Inherited { workspace: true } => {
+            Some(Inheritable::Value(v)) => v.clone(),
+            Some(Inheritable::Inherited { workspace: true }) => {
                 let workspace = workspace_manifest
                     .ok_or(Error::InheritanceMissingWorkspace)?
                     .workspace
@@ -69,7 +69,8 @@ impl<'a> ApkBuilder<'a> {
                     .version
                     .ok_or(Error::WorkspaceMissingInheritedField("package.version"))?
             }
-            Inheritable::Inherited { workspace: false } => return Err(Error::InheritedFalse),
+            Some(Inheritable::Inherited { workspace: false }) => return Err(Error::InheritedFalse),
+            None => String::from("0.0.0"),
         };
         let version_code = VersionCode::from_semver(&package_version)?.to_code(1);
 

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -16,7 +16,7 @@ pub enum Inheritable<T> {
 }
 
 pub(crate) struct Manifest {
-    pub(crate) version: Inheritable<String>,
+    pub(crate) version: Option<Inheritable<String>>,
     pub(crate) apk_name: Option<String>,
     pub(crate) android_manifest: AndroidManifest,
     pub(crate) build_targets: Vec<Target>,
@@ -72,7 +72,7 @@ impl Root {
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct Package {
-    pub(crate) version: Inheritable<String>,
+    pub(crate) version: Option<Inheritable<String>>,
     pub(crate) metadata: Option<PackageMetadata>,
 }
 


### PR DESCRIPTION
The `package.version` field in `Cargo.toml` is optional [since Cargo 1.75](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28). When not present, the default value is `0.0.0`. This PR adds that support to `cargo-apk` so that it will function properly with modern `Cargo.toml` files which don't have that field set.