### PR TITLE
Supports `resource` attribute for MetaData

### DIFF
--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -181,7 +181,6 @@ uses_cleartext_traffic = true
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #
 # Note: there can be several .meta_data entries.
-# Note: the `resource` attribute is currently not supported.
 [[package.metadata.android.application.meta_data]]
 name = "com.samsung.android.vr.application.mode"
 value = "vr_only"
@@ -225,7 +224,6 @@ always_retain_task_state = true
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #
 # Note: there can be several .meta_data entries.
-# Note: the `resource` attribute is currently not supported.
 [[package.metadata.android.application.activity.meta_data]]
 name = "com.oculus.vr.focusaware"
 value = "true"

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -176,7 +176,8 @@ impl<'a> ApkBuilder<'a> {
 
         manifest.application.activity.meta_data.push(MetaData {
             name: "android.app.lib_name".to_string(),
-            value: artifact.name.replace('-', "_"),
+            value: Some(artifact.name.replace('-', "_")),
+            resource: None,
         });
 
         let crate_path = self.cmd.manifest().parent().expect("invalid manifest path");

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -220,7 +220,9 @@ pub struct MetaData {
     #[serde(rename(serialize = "android:name"))]
     pub name: String,
     #[serde(rename(serialize = "android:value"))]
-    pub value: String,
+    pub value: Option<String>,
+    #[serde(rename(serialize = "android:resource"))]
+    pub resource: Option<String>,
 }
 
 /// Android [uses-feature element](https://developer.android.com/guide/topics/manifest/uses-feature-element).


### PR DESCRIPTION
I have to make this patch for configuring USB permission: <https://developer.android.com/develop/connectivity/usb/host>.

PS: I don't know how to request for permission at runtime without having Java and Gradle: <https://github.com/rust-mobile/cargo-apk/issues/19>, because `UsbManager.requestPermission()` is not a blocking function.
