### PR TITLE
Fix building packages with bin targets

### DIFF
--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use cargo_apk::{ApkBuilder, Error};
-use cargo_subcommand::Subcommand;
+use cargo_subcommand::{ArtifactType, Subcommand};
 use clap::{CommandFactory, FromArgMatches, Parser};
 
 #[derive(Parser)]
@@ -152,7 +152,7 @@ fn main() -> anyhow::Result<()> {
         ApkSubCmd::Build { args } => {
             let cmd = Subcommand::new(args.subcommand_args)?;
             let builder = ApkBuilder::from_subcommand(&cmd, args.device)?;
-            for artifact in cmd.artifacts() {
+            for artifact in cmd.artifacts().filter(|a| a.r#type == ArtifactType::Lib) {
                 builder.build(artifact)?;
             }
         }


### PR DESCRIPTION
I have a cross-platform application that needs to build a bin target on Windows, macOS, and Linux (at minimum). `cargo-apk` attempts to build my bin target as a `cdylib`, and explodes after signing the first artifact:

```
thread 'main' panicked at /home/jay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-subcommand-0.12.0/src/artifact.rs:51:23:
Bin is not compatible with Cdylib
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: cargo_subcommand::artifact::Artifact::file_name
   3: cargo_subcommand::subcommand::Subcommand::artifact
   4: cargo_apk::apk::ApkBuilder::build
   5: cargo_apk::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This fixes the panic by filtering artifacts to only build libraries.

I couldn't find an open issue for this, but there is a related comment in https://github.com/rust-mobile/cargo-apk/issues/23#issuecomment-1720945135