### PR TITLE
Support manifest XML overriding, dex insertion and multiple activities

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download hello_world APK
         if: ${{ matrix.source_os != 'local' }}
         id: download

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Cargo apk build for target ${{ matrix.rust-target }}
         run: cargo apk build -p ndk-examples --target ${{ matrix.rust-target }} --examples
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         # Only need this for CI, unless users are interested in downloading
         # a ready-made app that does nothing but printing "hello world".
         if: ${{ matrix.rust-target == 'x86_64-linux-android' && matrix.rust-channel == 'stable' }}
@@ -143,10 +143,10 @@ jobs:
           script: ./.github/workflows/android_test.sh "${{ steps.download.outputs.download-path }}"
 
       - name: Upload emulator logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: log
+          name: app-logs-${{ matrix.source_os }}
           path: ~/logcat.log
 
   build-host:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,19 +34,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust-channel: ["stable", "nightly"]
+        rust-channel: [stable, nightly]
         rust-target:
-          - "armv7-linux-androideabi"
-          - "aarch64-linux-android"
-          - "i686-linux-android"
-          - "x86_64-linux-android"
+          - armv7-linux-androideabi
+          - aarch64-linux-android
+          - i686-linux-android
+          - x86_64-linux-android
         include:
           - os: windows-latest
-            rust-channel: "stable"
-            rust-target: "aarch64-linux-android"
+            rust-channel: stable
+            rust-target: aarch64-linux-android
           - os: windows-latest
-            rust-channel: "stable"
-            rust-target: "x86_64-linux-android"
+            rust-channel: stable
+            rust-target: x86_64-linux-android
+          - os: macos-latest
+            rust-channel: stable
+            rust-target: x86_64-linux-android
 
     runs-on: ${{ matrix.os }}
     name: Build apk
@@ -78,10 +81,10 @@ jobs:
   android_emulator:
     name: hello_world example on emulator
     needs: build
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        source_os: [ubuntu-latest, windows-latest, local]
+        source_os: [local, windows-latest, macos-latest]
     env:
       api-level: 29
       emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -91,6 +94,13 @@ jobs:
       profile: Nexus 6
 
     steps:
+      # https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -154,7 +164,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust-channel: ["stable", "nightly"]
+        rust-channel: [stable, nightly]
 
     runs-on: ${{ matrix.os }}
     name: Host-side tests
@@ -178,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust-channel: ["stable", "nightly"]
+        rust-channel: [stable, nightly]
 
     runs-on: ${{ matrix.os }}
     name: Build-test docs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         source_os: [local, windows-latest, macos-latest]
     env:
-      api-level: 29
+      api-level: 35
       emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
       arch: x86_64
       # the `googleapis` emulator target is considerably slower on CI.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "ndk-build",
     "ndk-examples",

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **Breaking:** Default `target_sdk_version` to `35` (if installed), matching Google Play requirements starting August 31 2025.
+
 # 0.10.0 (2023-11-30)
 
 - Bump MSRV to 1.70 to reflect dependency updates.

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 - **Breaking:** Default `target_sdk_version` to `35` (if installed), matching Google Play requirements starting August 31 2025.
+- Support using the user-specified android manifest file.
+- Support user-declared activities aside from the first main native activity.
+- Add Dex data insertion feature.
+- Fix all new `clippy` lints up to Rust 1.88.
 
 # 0.10.0 (2023-11-30)
 

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -35,6 +35,14 @@ $ cargo install --path cargo-apk/
 
 Invoke `cargo apk help` for a more detailed overview of all available commands and their options (`cargo apk run --help` or `cargo apk help run` for example).
 
+## Dex File
+
+Although Dex files can be loaded by Android `DexClassLoader` on runtime, custom activities and services must be
+defined in the package's `classes.dex` file to avoid the `LoadedApk.mClassLoader` runtime replacement hack.
+
+Currently the Dex file can be built by the application's build script with [android-build](https://docs.rs/android-build),
+the Dex output path should be `<CARGO_MANIFEST_DIR>/target/<PROFILE>` to be picked up by `cargo-apk`.
+
 ## Manifest
 
 `cargo` supports the `metadata` table for configurations for external tools like `cargo apk`.
@@ -108,13 +116,18 @@ shared_user_id = "my.shared.user.id"
 path = "relative/or/absolute/path/to/my.keystore"
 keystore_password = "android"
 
+# Uncomment this item to use the existing Android manifest file instead of generating it.
+# This is useful for specifying manifest items not supported by `cargo-apk`.
+# Note: All configurations below will be *ignored* if the XML file is used!
+# android_manifest_file = "AndroidManifest.xml"
+
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element
 #
 # Defaults to a `min_sdk_version` of `23` and `target_sdk_version` of `35` (or lower if the detected NDK doesn't support this).
 [package.metadata.android.sdk]
 min_sdk_version = 23
-target_sdk_version = 30
-max_sdk_version = 29
+target_sdk_version = 35
+max_sdk_version = 35
 
 # See https://developer.android.com/guide/topics/manifest/uses-feature-element
 #
@@ -252,6 +265,11 @@ port = "8080"
 path = "/rust-windowing/android-ndk-rs/tree/master/cargo-apk"
 path_prefix = "/rust-windowing/"
 mime_type = "image/jpeg"
+
+# Declares custom activities from the Dex data. `name` should be specified,
+# and other elements in `activity` are supported.
+[[package.metadata.android.application.other_activity]]
+name = "com.github.alexmoon.bluest.android.PermissionActivity"
 
 # Set up reverse port forwarding through `adb reverse`, meaning that if the
 # Android device connects to `localhost` on port `1338` it will be routed to

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -110,7 +110,7 @@ keystore_password = "android"
 
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element
 #
-# Defaults to a `min_sdk_version` of 23 and `target_sdk_version` of 30 (or lower if the detected NDK doesn't support this).
+# Defaults to a `min_sdk_version` of `23` and `target_sdk_version` of `35` (or lower if the detected NDK doesn't support this).
 [package.metadata.android.sdk]
 min_sdk_version = 23
 target_sdk_version = 30

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -157,18 +157,6 @@ impl<'a> ApkBuilder<'a> {
     }
 
     pub fn build(&self, artifact: &Artifact) -> Result<Apk, Error> {
-        let dexes: Vec<_> =
-            if let Ok(read_dir) = std::fs::read_dir(self.build_dir.parent().unwrap()) {
-                read_dir
-                    .filter_map(|entry| entry.ok())
-                    .filter(|entry| entry.file_type().map(|t| t.is_file()).unwrap_or(false))
-                    .map(|entry| entry.path())
-                    .filter(|path| path.extension() == Some(std::ffi::OsStr::new("dex")))
-                    .collect()
-            } else {
-                Vec::new()
-            };
-
         // Set artifact specific manifest default values.
         let mut android_manifest = self.manifest.android_manifest.clone();
         if let AndroidManifestInput::FromToml(ref mut manifest) = android_manifest {
@@ -189,8 +177,6 @@ impl<'a> ApkBuilder<'a> {
                 name: "android.app.lib_name".to_string(),
                 value: artifact.name.replace('-', "_"),
             });
-
-            manifest.application.has_code = !dexes.is_empty();
         }
 
         let crate_path = self.cmd.manifest().parent().expect("invalid manifest path");
@@ -218,20 +204,7 @@ impl<'a> ApkBuilder<'a> {
             .clone()
             .unwrap_or_else(|| artifact.name.to_string());
 
-        let config = ApkConfig {
-            ndk: self.ndk.clone(),
-            build_dir: self.build_dir.join(artifact.build_dir()),
-            apk_name,
-            assets,
-            resources,
-            dexes,
-            manifest: android_manifest,
-            disable_aapt_compression: is_debug_profile,
-            strip: self.manifest.strip,
-            reverse_port_forward: self.manifest.reverse_port_forward.clone(),
-        };
-        let mut apk = config.create_apk()?;
-
+        let mut built_libs = Vec::with_capacity(self.build_targets.len());
         for target in &self.build_targets {
             let triple = target.rust_triple();
             let build_dir = self.cmd.build_dir(Some(triple));
@@ -257,15 +230,47 @@ impl<'a> ApkBuilder<'a> {
                 get_libs_search_paths(self.cmd.target_dir(), triple, self.cmd.profile().as_ref())?;
             libs_search_paths.push(build_dir.join("deps"));
 
+            built_libs.push((artifact, *target, libs_search_paths));
+        }
+
+        let dexes: Vec<_> =
+            if let Ok(read_dir) = std::fs::read_dir(self.build_dir.parent().unwrap()) {
+                read_dir
+                    .filter_map(|entry| entry.ok())
+                    .filter(|entry| entry.file_type().map(|t| t.is_file()).unwrap_or(false))
+                    .map(|entry| entry.path())
+                    .filter(|path| path.extension() == Some(std::ffi::OsStr::new("dex")))
+                    .collect()
+            } else {
+                Vec::new()
+            };
+        if let AndroidManifestInput::FromToml(ref mut manifest) = android_manifest {
+            manifest.application.has_code = !dexes.is_empty();
+        }
+
+        let config = ApkConfig {
+            ndk: self.ndk.clone(),
+            build_dir: self.build_dir.join(artifact.build_dir()),
+            apk_name,
+            assets,
+            resources,
+            dexes,
+            manifest: android_manifest,
+            disable_aapt_compression: is_debug_profile,
+            strip: self.manifest.strip,
+            reverse_port_forward: self.manifest.reverse_port_forward.clone(),
+        };
+
+        let mut apk = config.create_apk()?;
+
+        for (artifact, target, libs_search_paths) in built_libs {
             let libs_search_paths = libs_search_paths
                 .iter()
                 .map(|path| path.as_path())
                 .collect::<Vec<_>>();
-
-            apk.add_lib_recursively(&artifact, *target, libs_search_paths.as_slice())?;
-
+            apk.add_lib_recursively(&artifact, target, libs_search_paths.as_slice())?;
             if let Some(runtime_libs) = &runtime_libs {
-                apk.add_runtime_libs(runtime_libs, *target, libs_search_paths.as_slice())?;
+                apk.add_runtime_libs(runtime_libs, target, libs_search_paths.as_slice())?;
             }
         }
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -5,7 +5,7 @@ use ndk_build::apk::{Apk, ApkConfig};
 use ndk_build::cargo::{cargo_ndk, VersionCode};
 use ndk_build::dylibs::get_libs_search_paths;
 use ndk_build::error::NdkError;
-use ndk_build::manifest::{IntentFilter, MetaData};
+use ndk_build::manifest::{AndroidManifestInput, IntentFilter, MetaData};
 use ndk_build::ndk::{Key, Ndk};
 use ndk_build::target::Target;
 use std::path::PathBuf;
@@ -74,56 +74,55 @@ impl<'a> ApkBuilder<'a> {
         let version_code = VersionCode::from_semver(&package_version)?.to_code(1);
 
         // Set default Android manifest values
-        if manifest
-            .android_manifest
-            .version_name
-            .replace(package_version)
-            .is_some()
+        if let AndroidManifestInput::FromToml(ref mut android_manifest) = manifest.android_manifest
         {
-            panic!("version_name should not be set in TOML");
-        }
+            if android_manifest
+                .version_name
+                .replace(package_version)
+                .is_some()
+            {
+                panic!("version_name should not be set in TOML");
+            }
 
-        if manifest
-            .android_manifest
-            .version_code
-            .replace(version_code)
-            .is_some()
-        {
-            panic!("version_code should not be set in TOML");
-        }
+            if android_manifest
+                .version_code
+                .replace(version_code)
+                .is_some()
+            {
+                panic!("version_code should not be set in TOML");
+            }
 
-        let target_sdk_version = *manifest
-            .android_manifest
-            .sdk
-            .target_sdk_version
-            .get_or_insert_with(|| ndk.default_target_platform());
+            let target_sdk_version = android_manifest
+                .sdk
+                .target_sdk_version
+                .get_or_insert_with(|| ndk.default_target_platform());
 
-        manifest
-            .android_manifest
-            .application
-            .debuggable
-            .get_or_insert_with(|| *cmd.profile() == Profile::Dev);
+            android_manifest
+                .application
+                .debuggable
+                .get_or_insert_with(|| *cmd.profile() == Profile::Dev);
 
-        let activity = &mut manifest.android_manifest.application.activity;
+            let activity = &mut android_manifest.application.activity;
 
-        // Add a default `MAIN` action to launch the activity, if the user didn't supply it by hand.
-        if activity
-            .intent_filter
-            .iter()
-            .all(|i| i.actions.iter().all(|f| f != "android.intent.action.MAIN"))
-        {
-            activity.intent_filter.push(IntentFilter {
-                actions: vec!["android.intent.action.MAIN".to_string()],
-                categories: vec!["android.intent.category.LAUNCHER".to_string()],
-                data: vec![],
-            });
-        }
+            // Add a default `MAIN` action to launch the activity, if the user didn't supply it by hand.
+            if activity
+                .intent_filter
+                .iter()
+                .all(|i| i.actions.iter().all(|f| f != "android.intent.action.MAIN"))
+            {
+                activity.intent_filter.push(IntentFilter {
+                    actions: vec!["android.intent.action.MAIN".into()],
+                    categories: vec!["android.intent.category.LAUNCHER".into()],
+                    data: vec![],
+                });
+            }
 
-        // Export the sole Rust activity on Android S and up, if the user didn't explicitly do so.
-        // Without this, apps won't start on S+.
-        // https://developer.android.com/about/versions/12/behavior-changes-12#exported
-        if target_sdk_version >= 31 {
-            activity.exported.get_or_insert(true);
+            // Export the sole Rust activity on Android S and up, if the user didn't explicitly do so.
+            // Without this, apps won't start on S+.
+            // https://developer.android.com/about/versions/12/behavior-changes-12#exported
+            if *target_sdk_version >= 31 {
+                activity.exported.get_or_insert(true);
+            }
         }
 
         Ok(Self {
@@ -158,26 +157,41 @@ impl<'a> ApkBuilder<'a> {
     }
 
     pub fn build(&self, artifact: &Artifact) -> Result<Apk, Error> {
-        // Set artifact specific manifest default values.
-        let mut manifest = self.manifest.android_manifest.clone();
-
-        if manifest.package.is_empty() {
-            let name = artifact.name.replace('-', "_");
-            manifest.package = match artifact.r#type {
-                ArtifactType::Lib => format!("rust.{name}"),
-                ArtifactType::Bin => format!("rust.{name}"),
-                ArtifactType::Example => format!("rust.example.{name}"),
+        let dexes: Vec<_> =
+            if let Ok(read_dir) = std::fs::read_dir(self.build_dir.parent().unwrap()) {
+                read_dir
+                    .filter_map(|entry| entry.ok())
+                    .filter(|entry| entry.file_type().map(|t| t.is_file()).unwrap_or(false))
+                    .map(|entry| entry.path())
+                    .filter(|path| path.extension() == Some(std::ffi::OsStr::new("dex")))
+                    .collect()
+            } else {
+                Vec::new()
             };
-        }
 
-        if manifest.application.label.is_empty() {
-            manifest.application.label = artifact.name.to_string();
-        }
+        // Set artifact specific manifest default values.
+        let mut android_manifest = self.manifest.android_manifest.clone();
+        if let AndroidManifestInput::FromToml(ref mut manifest) = android_manifest {
+            if manifest.package.is_empty() {
+                let name = artifact.name.replace('-', "_");
+                manifest.package = match artifact.r#type {
+                    ArtifactType::Lib => format!("rust.{name}"),
+                    ArtifactType::Bin => format!("rust.{name}"),
+                    ArtifactType::Example => format!("rust.example.{name}"),
+                };
+            }
 
-        manifest.application.activity.meta_data.push(MetaData {
-            name: "android.app.lib_name".to_string(),
-            value: artifact.name.replace('-', "_"),
-        });
+            if manifest.application.label.is_empty() {
+                manifest.application.label = artifact.name.to_string();
+            }
+
+            manifest.application.activity.meta_data.push(MetaData {
+                name: "android.app.lib_name".to_string(),
+                value: artifact.name.replace('-', "_"),
+            });
+
+            manifest.application.has_code = !dexes.is_empty();
+        }
 
         let crate_path = self.cmd.manifest().parent().expect("invalid manifest path");
 
@@ -210,7 +224,8 @@ impl<'a> ApkBuilder<'a> {
             apk_name,
             assets,
             resources,
-            manifest,
+            dexes,
+            manifest: android_manifest,
             disable_aapt_compression: is_debug_profile,
             strip: self.manifest.strip,
             reverse_port_forward: self.manifest.reverse_port_forward.clone(),
@@ -373,11 +388,9 @@ impl<'a> ApkBuilder<'a> {
     /// Has a lower bound of `23` to retain backwards compatibility with
     /// the previous default.
     fn min_sdk_version(&self) -> u32 {
-        self.manifest
-            .android_manifest
-            .sdk
-            .min_sdk_version
-            .unwrap_or(23)
-            .max(23)
+        let Ok(manifest) = self.manifest.android_manifest.get_manifest_info() else {
+            return 23;
+        };
+        manifest.sdk.min_sdk_version.unwrap_or(23).max(23)
     }
 }

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use ndk_build::apk::StripConfig;
-use ndk_build::manifest::AndroidManifest;
+use ndk_build::manifest::{AndroidManifest, AndroidManifestInput};
 use ndk_build::target::Target;
 use serde::Deserialize;
 use std::{
@@ -18,7 +18,7 @@ pub enum Inheritable<T> {
 pub(crate) struct Manifest {
     pub(crate) version: Inheritable<String>,
     pub(crate) apk_name: Option<String>,
-    pub(crate) android_manifest: AndroidManifest,
+    pub(crate) android_manifest: AndroidManifestInput,
     pub(crate) build_targets: Vec<Target>,
     pub(crate) assets: Option<PathBuf>,
     pub(crate) resources: Option<PathBuf>,
@@ -42,10 +42,24 @@ impl Manifest {
             .unwrap_or_default()
             .android
             .unwrap_or_default();
+        let android_manifest = if let Some(ref file) = metadata.android_manifest_file {
+            println!(
+                "Using the *unchecked* user-specified Android manifest file `{}`",
+                file.display()
+            );
+            AndroidManifestInput::FromXml(path.parent().unwrap().join(file))
+        } else if let Some(ref manifest) = metadata.android_manifest {
+            AndroidManifestInput::FromToml(manifest.clone())
+        } else {
+            println!(
+                "`android_manifest_file` is unspecified, and Android manifest info cannot be parsed from {path:?}"
+            );
+            AndroidManifestInput::FromToml(AndroidManifest::default())
+        };
         Ok(Self {
             version: package.version,
             apk_name: metadata.apk_name,
-            android_manifest: metadata.android_manifest,
+            android_manifest,
             build_targets: metadata.build_targets,
             assets: metadata.assets,
             resources: metadata.resources,
@@ -97,7 +111,8 @@ pub(crate) struct PackageMetadata {
 struct AndroidMetadata {
     apk_name: Option<String>,
     #[serde(flatten)]
-    android_manifest: AndroidManifest,
+    android_manifest: Option<AndroidManifest>,
+    android_manifest_file: Option<PathBuf>,
     #[serde(default)]
     build_targets: Vec<Target>,
     assets: Option<PathBuf>,

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- Fix all new `clippy` lints up to Rust 1.88.
+- Enable *partial* `AndroidManifest` parsing from `AndroidManifest.xml` file.
+- **Breaking:** Add `AndroidManifestInput` enum and support using the user-specified android manifest file.
+- Support user-declared activities aside from the first main native activity.
+- Add Dex data insertion feature.
+
 # 0.10.0 (2023-11-30)
 
 - Add `android:extractNativeLibs`, `android:usesCleartextTraffic` attributes to the manifest's `Application` element, and `android:alwaysRetainTaskState` to the `Activity` element. ([#15](https://github.com/rust-mobile/cargo-apk/pull/15))

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -18,4 +18,3 @@ quick-xml = { version = "0.26", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 which = "4"
-zip = "1"

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -18,3 +18,4 @@ quick-xml = { version = "0.26", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 which = "4"
+zip = "1"

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -6,10 +6,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use zip::ZipWriter;
 
 /// The options for how to treat debug symbols that are present in any `.so`
 /// files that are added to the APK.
@@ -105,26 +103,17 @@ impl ApkConfig {
         }
 
         if !self.dexes.is_empty() {
-            // TODO: try to eliminate the `zip     : warning: header mismatch` warning.
-            let map_zip_err = |e: zip::result::ZipError| std::io::Error::from(e);
-            let mut apk_file = fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(self.unaligned_apk())?;
+            let mut aapt = self.build_tool(bin!("aapt"))?;
+            aapt.arg("add").arg("-k");
+            if self.disable_aapt_compression {
+                aapt.arg("-0").arg("");
+            }
+            aapt.arg(self.unaligned_apk());
             for dex_path in &self.dexes {
-                let dex_data = fs::read(dex_path)?;
-                let mut apk_zip = ZipWriter::new_append(&mut apk_file).map_err(map_zip_err)?;
-                let Some(dex_file_name) = dex_path.file_name().map(|s| s.to_string_lossy()) else {
-                    continue;
-                };
-                apk_zip
-                    .start_file(
-                        dex_file_name.as_ref(),
-                        zip::write::SimpleFileOptions::default(),
-                    )
-                    .map_err(map_zip_err)?;
-                apk_zip.write_all(&dex_data).unwrap();
-                apk_zip.finish().map_err(map_zip_err)?;
+                aapt.arg(dex_path);
+            }
+            if !aapt.status()?.success() {
+                return Err(NdkError::CmdFailed(Box::new(aapt)));
             }
         }
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -105,9 +105,7 @@ impl ApkConfig {
         }
 
         if !self.dexes.is_empty() {
-            // XXX: import `android-build` and use `Dexer` (D8) to add dex files into the apk,
-            // then remove `zip` dependency to reduce crate size and eliminate the annoying
-            // `zip     : warning: header mismatch` warning.
+            // TODO: try to eliminate the `zip     : warning: header mismatch` warning.
             let map_zip_err = |e: zip::result::ZipError| std::io::Error::from(e);
             let mut apk_file = fs::OpenOptions::new()
                 .read(true)

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -1,13 +1,15 @@
 use crate::error::NdkError;
-use crate::manifest::AndroidManifest;
+use crate::manifest::AndroidManifestInput;
 use crate::ndk::{Key, Ndk};
 use crate::target::Target;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use zip::ZipWriter;
 
 /// The options for how to treat debug symbols that are present in any `.so`
 /// files that are added to the APK.
@@ -40,7 +42,8 @@ pub struct ApkConfig {
     pub apk_name: String,
     pub assets: Option<PathBuf>,
     pub resources: Option<PathBuf>,
-    pub manifest: AndroidManifest,
+    pub dexes: Vec<PathBuf>,
+    pub manifest: AndroidManifestInput,
     pub disable_aapt_compression: bool,
     pub strip: StripConfig,
     pub reverse_port_forward: HashMap<String, String>,
@@ -71,6 +74,7 @@ impl ApkConfig {
 
         let target_sdk_version = self
             .manifest
+            .get_manifest_info()?
             .sdk
             .target_sdk_version
             .unwrap_or_else(|| self.ndk.default_target_platform());
@@ -98,6 +102,32 @@ impl ApkConfig {
 
         if !aapt.status()?.success() {
             return Err(NdkError::CmdFailed(Box::new(aapt)));
+        }
+
+        if !self.dexes.is_empty() {
+            // XXX: import `android-build` and use `Dexer` (D8) to add dex files into the apk,
+            // then remove `zip` dependency to reduce crate size and eliminate the annoying
+            // `zip     : warning: header mismatch` warning.
+            let map_zip_err = |e: zip::result::ZipError| std::io::Error::from(e);
+            let mut apk_file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(self.unaligned_apk())?;
+            for dex_path in &self.dexes {
+                let dex_data = fs::read(dex_path)?;
+                let mut apk_zip = ZipWriter::new_append(&mut apk_file).map_err(map_zip_err)?;
+                let Some(dex_file_name) = dex_path.file_name().map(|s| s.to_string_lossy()) else {
+                    continue;
+                };
+                apk_zip
+                    .start_file(
+                        dex_file_name.as_ref(),
+                        zip::write::SimpleFileOptions::default(),
+                    )
+                    .map_err(map_zip_err)?;
+                apk_zip.write_all(&dex_data).unwrap();
+                apk_zip.finish().map_err(map_zip_err)?;
+            }
         }
 
         Ok(UnalignedApk {
@@ -245,7 +275,7 @@ impl<'a> UnsignedApk<'a> {
         if !apksigner.status()?.success() {
             return Err(NdkError::CmdFailed(Box::new(apksigner)));
         }
-        Ok(Apk::from_config(self.0))
+        Apk::from_config(self.0)
     }
 }
 
@@ -257,14 +287,14 @@ pub struct Apk {
 }
 
 impl Apk {
-    pub fn from_config(config: &ApkConfig) -> Self {
+    pub fn from_config(config: &ApkConfig) -> Result<Self, NdkError> {
         let ndk = config.ndk.clone();
-        Self {
+        Ok(Self {
             path: config.apk(),
-            package_name: config.manifest.package.clone(),
+            package_name: config.manifest.get_manifest_info()?.package.clone(),
             ndk,
             reverse_port_forward: config.reverse_port_forward.clone(),
-        }
+        })
     }
 
     pub fn reverse_port_forwarding(&self, device_serial: Option<&str>) -> Result<(), NdkError> {

--- a/ndk-build/src/error.rs
+++ b/ndk-build/src/error.rs
@@ -48,6 +48,8 @@ pub enum NdkError {
     CmdFailed(Box<Command>),
     #[error(transparent)]
     Serialize(#[from] quick_xml::de::DeError),
+    #[error(transparent)]
+    QuickXml(#[from] quick_xml::Error),
     #[error("String `{1}` is not a UID")]
     NotAUid(#[source] ParseIntError, String),
     #[error("Could not find `package:{package}` in output `{output}`")]

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -100,8 +100,42 @@ impl AndroidManifest {
     }
 
     pub fn read_from(xml_file: &Path) -> Result<Self, NdkError> {
+        use quick_xml::events::{BytesEnd, BytesStart, Event};
+        use std::io::Cursor;
+
+        let alt_str = |is_first| {
+            if is_first {
+                "activity"
+            } else {
+                "other_activity"
+            }
+        };
+
         let xml = std::fs::read_to_string(xml_file)?;
-        let manifest = quick_xml::de::from_str(&xml)?;
+        let mut reader = quick_xml::Reader::from_str(&xml);
+        reader.trim_text(true); // XXX: is it needed?
+
+        let mut writer = quick_xml::Writer::new(Cursor::new(Vec::new()));
+        let mut is_first_activity = true;
+        loop {
+            match reader.read_event()? {
+                Event::Start(ref e) if e.name().as_ref() == b"activity" => {
+                    let mut new_start = BytesStart::new(alt_str(is_first_activity));
+                    new_start.extend_attributes(e.attributes().filter_map(Result::ok));
+                    writer.write_event(Event::Start(new_start))?;
+                }
+                Event::End(ref e) if e.name().as_ref() == b"activity" => {
+                    let new_end = BytesEnd::new(alt_str(is_first_activity));
+                    writer.write_event(Event::End(new_end))?;
+                    is_first_activity = false;
+                }
+                Event::Eof => break,
+                e => writer.write_event(e)?,
+            }
+        }
+        let mut buf = writer.into_inner();
+        buf.set_position(0);
+        let manifest = quick_xml::de::from_reader(buf)?;
         Ok(manifest)
     }
 }
@@ -135,7 +169,7 @@ pub struct Application {
     /// This is usually the native activity.
     #[serde(default)]
     pub activity: Activity,
-    /// Note: this is unsupported in XML deserialization.
+    /// Note: this must be handled by `AndroidManifest::read_from` for XML deserialization.
     #[serde(default)]
     #[serde(rename(serialize = "activity", deserialize = "other_activity"))]
     pub other_activities: Vec<Activity>,

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -1,31 +1,69 @@
 use crate::error::NdkError;
 use serde::{Deserialize, Serialize, Serializer};
-use std::{fs::File, path::Path};
+use std::{
+    borrow::Cow,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+/// Represents either an [`AndroidManifest`] parsed from the Cargo manifest file, or the path to the specified Android manifest file.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+pub enum AndroidManifestInput {
+    FromToml(AndroidManifest),
+    FromXml(PathBuf),
+}
+
+impl AndroidManifestInput {
+    pub fn is_xml(&self) -> bool {
+        matches!(self, AndroidManifestInput::FromXml(_))
+    }
+
+    /// Returns the `AndroidManifest` information, either cloned or parsed.
+    /// If it is parsed, some items in the XML may be missing in the parsed information.
+    pub fn get_manifest_info(&self) -> Result<Cow<AndroidManifest>, NdkError> {
+        Ok(match &self {
+            AndroidManifestInput::FromToml(manifest) => Cow::Borrowed(manifest),
+            AndroidManifestInput::FromXml(file) => Cow::Owned(AndroidManifest::read_from(file)?),
+        })
+    }
+
+    pub fn write_to(&self, dir: &Path) -> Result<(), NdkError> {
+        match &self {
+            AndroidManifestInput::FromToml(manifest) => manifest.write_to(dir),
+            AndroidManifestInput::FromXml(file) => {
+                Ok(std::fs::copy(file, dir.join("AndroidManifest.xml")).map(|_| ())?)
+            }
+        }
+    }
+}
+
+// Note: these serde `rename`s are XML names for XML (de)serialization; `alias`es are for TOML deserialization.
 
 /// Android [manifest element](https://developer.android.com/guide/topics/manifest/manifest-element), containing an [`Application`] element.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename = "manifest")]
 pub struct AndroidManifest {
-    #[serde(rename(serialize = "xmlns:android"))]
+    #[serde(rename = "xmlns:android", alias = "ns_android")]
     #[serde(default = "default_namespace")]
     ns_android: String,
     #[serde(default)]
     pub package: String,
-    #[serde(rename(serialize = "android:sharedUserId"))]
+    #[serde(rename = "android:sharedUserId", alias = "shared_user_id")]
     pub shared_user_id: Option<String>,
-    #[serde(rename(serialize = "android:versionCode"))]
+    #[serde(rename = "android:versionCode", alias = "version_code")]
     pub version_code: Option<u32>,
-    #[serde(rename(serialize = "android:versionName"))]
+    #[serde(rename = "android:versionName", alias = "version_name")]
     pub version_name: Option<String>,
 
-    #[serde(rename(serialize = "uses-sdk"))]
+    #[serde(rename = "uses-sdk", alias = "sdk")]
     #[serde(default)]
     pub sdk: Sdk,
 
-    #[serde(rename(serialize = "uses-feature"))]
+    #[serde(rename = "uses-feature", alias = "uses_feature")]
     #[serde(default)]
     pub uses_feature: Vec<Feature>,
-    #[serde(rename(serialize = "uses-permission"))]
+    #[serde(rename = "uses-permission", alias = "uses_permission")]
     #[serde(default)]
     pub uses_permission: Vec<Permission>,
 
@@ -60,62 +98,79 @@ impl AndroidManifest {
         quick_xml::se::to_writer(w, &self)?;
         Ok(())
     }
+
+    pub fn read_from(xml_file: &Path) -> Result<Self, NdkError> {
+        let xml = std::fs::read_to_string(xml_file)?;
+        let manifest = quick_xml::de::from_str(&xml)?;
+        Ok(manifest)
+    }
 }
 
 /// Android [application element](https://developer.android.com/guide/topics/manifest/application-element), containing an [`Activity`] element.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Application {
-    #[serde(rename(serialize = "android:debuggable"))]
+    #[serde(rename = "android:debuggable", alias = "debuggable")]
     pub debuggable: Option<bool>,
-    #[serde(rename(serialize = "android:theme"))]
+    #[serde(rename = "android:theme", alias = "theme")]
     pub theme: Option<String>,
-    #[serde(rename(serialize = "android:hasCode"))]
+    #[serde(rename = "android:hasCode", alias = "has_code")]
     #[serde(default)]
     pub has_code: bool,
-    #[serde(rename(serialize = "android:icon"))]
+    #[serde(rename = "android:icon", alias = "icon")]
     pub icon: Option<String>,
-    #[serde(rename(serialize = "android:label"))]
+    #[serde(rename = "android:label", alias = "label")]
     #[serde(default)]
     pub label: String,
-    #[serde(rename(serialize = "android:extractNativeLibs"))]
+    #[serde(rename = "android:extractNativeLibs", alias = "extract_native_libs")]
     pub extract_native_libs: Option<bool>,
-    #[serde(rename(serialize = "android:usesCleartextTraffic"))]
+    #[serde(
+        rename = "android:usesCleartextTraffic",
+        alias = "uses_cleartext_traffic"
+    )]
     pub uses_cleartext_traffic: Option<bool>,
 
-    #[serde(rename(serialize = "meta-data"))]
+    #[serde(rename = "meta-data", alias = "meta_data")]
     #[serde(default)]
     pub meta_data: Vec<MetaData>,
+    /// This is usually the native activity.
     #[serde(default)]
     pub activity: Activity,
+    /// Note: this is unsupported in XML deserialization.
+    #[serde(default)]
+    #[serde(rename(serialize = "activity", deserialize = "other_activity"))]
+    pub other_activities: Vec<Activity>,
 }
 
 /// Android [activity element](https://developer.android.com/guide/topics/manifest/activity-element).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Activity {
-    #[serde(rename(serialize = "android:configChanges"))]
+    #[serde(rename = "android:configChanges", alias = "config_changes")]
     #[serde(default = "default_config_changes")]
     pub config_changes: Option<String>,
-    #[serde(rename(serialize = "android:label"))]
+    #[serde(rename = "android:label", alias = "label")]
     pub label: Option<String>,
-    #[serde(rename(serialize = "android:launchMode"))]
+    #[serde(rename = "android:launchMode", alias = "launch_mode")]
     pub launch_mode: Option<String>,
-    #[serde(rename(serialize = "android:name"))]
+    #[serde(rename = "android:name", alias = "name")]
     #[serde(default = "default_activity_name")]
     pub name: String,
-    #[serde(rename(serialize = "android:screenOrientation"))]
+    #[serde(rename = "android:screenOrientation", alias = "orientation")]
     pub orientation: Option<String>,
-    #[serde(rename(serialize = "android:exported"))]
+    #[serde(rename = "android:exported", alias = "exported")]
     pub exported: Option<bool>,
-    #[serde(rename(serialize = "android:resizeableActivity"))]
+    #[serde(rename = "android:resizeableActivity", alias = "resizeable_activity")]
     pub resizeable_activity: Option<bool>,
-    #[serde(rename(serialize = "android:alwaysRetainTaskState"))]
+    #[serde(
+        rename = "android:alwaysRetainTaskState",
+        alias = "always_retain_task_state"
+    )]
     pub always_retain_task_state: Option<bool>,
 
-    #[serde(rename(serialize = "meta-data"))]
+    #[serde(rename = "meta-data", alias = "meta_data")]
     #[serde(default)]
     pub meta_data: Vec<MetaData>,
     /// If no `MAIN` action exists in any intent filter, a default `MAIN` filter is serialized by `cargo-apk`.
-    #[serde(rename(serialize = "intent-filter"))]
+    #[serde(rename = "intent-filter", alias = "intent_filter")]
     #[serde(default)]
     pub intent_filter: Vec<IntentFilter>,
 }
@@ -138,6 +193,7 @@ impl Default for Activity {
 }
 
 /// Android [intent filter element](https://developer.android.com/guide/topics/manifest/intent-filter-element).
+/// Currently deserialization from XML is unsupported.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct IntentFilter {
     /// Serialize strings wrapped in `<action android:name="..." />`
@@ -198,37 +254,37 @@ where
 /// Android [intent filter data element](https://developer.android.com/guide/topics/manifest/data-element).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct IntentFilterData {
-    #[serde(rename(serialize = "android:scheme"))]
+    #[serde(rename = "android:scheme", alias = "scheme")]
     pub scheme: Option<String>,
-    #[serde(rename(serialize = "android:host"))]
+    #[serde(rename = "android:host", alias = "host")]
     pub host: Option<String>,
-    #[serde(rename(serialize = "android:port"))]
+    #[serde(rename = "android:port", alias = "port")]
     pub port: Option<String>,
-    #[serde(rename(serialize = "android:path"))]
+    #[serde(rename = "android:path", alias = "path")]
     pub path: Option<String>,
-    #[serde(rename(serialize = "android:pathPattern"))]
+    #[serde(rename = "android:pathPattern", alias = "path_pattern")]
     pub path_pattern: Option<String>,
-    #[serde(rename(serialize = "android:pathPrefix"))]
+    #[serde(rename = "android:pathPrefix", alias = "path_prefix")]
     pub path_prefix: Option<String>,
-    #[serde(rename(serialize = "android:mimeType"))]
+    #[serde(rename = "android:mimeType", alias = "mime_type")]
     pub mime_type: Option<String>,
 }
 
 /// Android [meta-data element](https://developer.android.com/guide/topics/manifest/meta-data-element).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MetaData {
-    #[serde(rename(serialize = "android:name"))]
+    #[serde(rename = "android:name", alias = "name")]
     pub name: String,
-    #[serde(rename(serialize = "android:value"))]
+    #[serde(rename = "android:value", alias = "value")]
     pub value: String,
 }
 
 /// Android [uses-feature element](https://developer.android.com/guide/topics/manifest/uses-feature-element).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Feature {
-    #[serde(rename(serialize = "android:name"))]
+    #[serde(rename = "android:name", alias = "name")]
     pub name: Option<String>,
-    #[serde(rename(serialize = "android:required"))]
+    #[serde(rename = "android:required", alias = "required")]
     pub required: Option<bool>,
     /// The `version` field is currently used for the following features:
     ///
@@ -240,13 +296,14 @@ pub struct Feature {
     ///
     /// - `name="android.hardware.vulkan.version"`: Represents the value of Vulkan's `VkPhysicalDeviceProperties::apiVersion`. See the [Android documentation](https://developer.android.com/reference/android/content/pm/PackageManager#FEATURE_VULKAN_HARDWARE_VERSION)
     ///   for available levels and the respective Vulkan features required/provided.
-    #[serde(rename(serialize = "android:version"))]
+    #[serde(rename = "android:version", alias = "version")]
     pub version: Option<u32>,
-    #[serde(rename(serialize = "android:glEsVersion"))]
+    #[serde(rename = "android:glEsVersion", alias = "opengles_version")]
     #[serde(serialize_with = "serialize_opengles_version")]
     pub opengles_version: Option<(u8, u8)>,
 }
 
+// XXX: implement a deserializer suitable for XML parsing
 fn serialize_opengles_version<S>(
     version: &Option<(u8, u8)>,
     serializer: S,
@@ -266,28 +323,28 @@ where
 /// Android [uses-permission element](https://developer.android.com/guide/topics/manifest/uses-permission-element).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Permission {
-    #[serde(rename(serialize = "android:name"))]
+    #[serde(rename = "android:name", alias = "name")]
     pub name: String,
-    #[serde(rename(serialize = "android:maxSdkVersion"))]
+    #[serde(rename = "android:maxSdkVersion", alias = "max_sdk_version")]
     pub max_sdk_version: Option<u32>,
 }
 
 /// Android [package element](https://developer.android.com/guide/topics/manifest/queries-element#package).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Package {
-    #[serde(rename(serialize = "android:name"))]
+    #[serde(rename = "android:name", alias = "name")]
     pub name: String,
 }
 
 /// Android [provider element](https://developer.android.com/guide/topics/manifest/queries-element#provider).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct QueryProvider {
-    #[serde(rename(serialize = "android:authorities"))]
+    #[serde(rename = "android:authorities", alias = "authorities")]
     pub authorities: String,
 
     // The specs say only an `authorities` attribute is required for providers contained in a `queries` element
     // however this is required for aapt support and should be made optional if/when cargo-apk migrates to aapt2
-    #[serde(rename(serialize = "android:name"))]
+    #[serde(rename = "android:name", alias = "name")]
     pub name: String,
 }
 
@@ -305,11 +362,11 @@ pub struct Queries {
 /// Android [uses-sdk element](https://developer.android.com/guide/topics/manifest/uses-sdk-element).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Sdk {
-    #[serde(rename(serialize = "android:minSdkVersion"))]
+    #[serde(rename = "android:minSdkVersion", alias = "min_sdk_version")]
     pub min_sdk_version: Option<u32>,
-    #[serde(rename(serialize = "android:targetSdkVersion"))]
+    #[serde(rename = "android:targetSdkVersion", alias = "target_sdk_version")]
     pub target_sdk_version: Option<u32>,
-    #[serde(rename(serialize = "android:maxSdkVersion"))]
+    #[serde(rename = "android:maxSdkVersion", alias = "max_sdk_version")]
     pub max_sdk_version: Option<u32>,
 }
 

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -202,12 +202,12 @@ impl Ndk {
         self.platforms().iter().max().cloned().unwrap()
     }
 
-    /// Returns platform `30` as currently [required by Google Play], or lower
+    /// Returns platform `35` as currently [required by Google Play], or lower
     /// when the detected SDK does not support it yet.
     ///
     /// [required by Google Play]: https://developer.android.com/distribute/best-practices/develop/target-sdk
     pub fn default_target_platform(&self) -> u32 {
-        self.highest_supported_platform().min(30)
+        self.highest_supported_platform().min(35)
     }
 
     pub fn platform_dir(&self, platform: u32) -> Result<PathBuf, NdkError> {

--- a/ndk-build/src/readelf.rs
+++ b/ndk-build/src/readelf.rs
@@ -18,6 +18,7 @@ impl<'a> UnalignedApk<'a> {
         let min_sdk_version = self
             .config()
             .manifest
+            .get_manifest_info()?
             .sdk
             .min_sdk_version
             .unwrap_or(default_min_sdk);

--- a/ndk-examples/Cargo.toml
+++ b/ndk-examples/Cargo.toml
@@ -1,18 +1,17 @@
 [package]
 name = "ndk-examples"
 version = "0.1.0"
-authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.20"
-libc = "0.2"
+rustix = { version = "1", features = ["pipe"] }
 log = "0.4.14"
-ndk = { version = "0.7", features = ["api-level-23"] }
+ndk = { version = "0.9", features = ["api-level-23"] }
 ndk-context = "0.1.1"
-android_logger = "0.11.0"
-android-activity = { version = "0.4", features = ["native-activity"] }
+android_logger = "0.15"
+android-activity = { version = "0.6", features = ["native-activity"] }
 
 [[example]]
 name = "hello_world"

--- a/ndk-examples/Cargo.toml
+++ b/ndk-examples/Cargo.toml
@@ -25,7 +25,3 @@ crate-type = ["cdylib"]
 [[example]]
 name = "looper"
 crate-type = ["cdylib"]
-
-[package.metadata.android.sdk]
-min_sdk_version = 16
-target_sdk_version = 29

--- a/ndk-examples/Cargo.toml
+++ b/ndk-examples/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [target.'cfg(target_os = "android")'.dependencies]
-jni = "0.20"
+jni = "0.21"
 rustix = { version = "1", features = ["pipe"] }
 log = "0.4.14"
 ndk = { version = "0.9", features = ["api-level-23"] }

--- a/ndk-examples/examples/hello_world.rs
+++ b/ndk-examples/examples/hello_world.rs
@@ -4,11 +4,13 @@ use ndk::trace;
 
 #[no_mangle]
 fn android_main(_app: AndroidApp) {
-    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Info));
+    android_logger::init_once(
+        android_logger::Config::default().with_max_level(log::LevelFilter::Info),
+    );
 
     let _trace;
     if trace::is_trace_enabled() {
-        _trace = trace::Section::new("ndk-rs example main").unwrap();
+        _trace = trace::Section::new("ndk-examples main").unwrap();
     }
 
     info!("hello world");

--- a/ndk-examples/examples/jni_audio.rs
+++ b/ndk-examples/examples/jni_audio.rs
@@ -3,7 +3,9 @@ use jni::objects::JObject;
 
 #[no_mangle]
 fn android_main(_app: AndroidApp) {
-    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Info));
+    android_logger::init_once(
+        android_logger::Config::default().with_max_level(log::LevelFilter::Info),
+    );
     enumerate_audio_devices().unwrap();
 }
 


### PR DESCRIPTION
Excuse me, the previous <https://github.com/rust-mobile/cargo-apk/pull/71> is closed, and some fixes are made here to recover my breaking changes.

Why did I make the breaking change for the `activity` element in the manifest?

When I added multiple activities in the overrided XML manifest file, `cargo-apk` still needs to parse the file into `AndroidManifest`; while the overriding feature makes specifying manifest elements unsupported by `ndk-build` possible, the single `activity` struct item still conflicts with multiple activity items declared in the XML (I got an runtime error); thus I have to change it.

I've tried this:

```rust
    #[serde(default)]
    pub activity: Activity,
    #[serde(default)]
    #[serde(rename = "activity", alias = "extra_activity")]
    pub extra_activities: Vec<Activity>,
```

It doesn't work, and this compilation warning occured:

```
warning: unreachable pattern
   --> /run/media/di945/500g_lin/home/di945/down/github/cargo-apk/ndk-build/src/manifest.rs:138:22
    |
136 |     pub activity: Activity,
    |         -------- matches all the relevant values
137 |     #[serde(default)]
138 |     #[serde(rename = "activity", alias = "extra_activity")]
    |                      ^^^^^^^^^^ no value can reach this
```

I changed the code again in order to **avoid** this breaking change, so `[package.metadata.android.application.activity]` will not need changing to `[[package.metadata.android.application.activity]]`, and other activities can be declared as `other_activity`):

```rust
    #[serde(default)]
    pub activity: Activity,
    #[serde(default)]
    #[serde(rename(serialize = "activity", deserialize = "other_activity"))]
    pub other_activities: Vec<Activity>,
```

However, this prevents `ndk-build` from parsing the manifest XML's multiple activities (except the first), the deserialing key `other_activity` is for TOML; but the information of extra activities is not needed by `cargo-apk` itself when performing manifest XML override...

So I gave up the idea of deserializing the XML file "perfectly" (who will use this feature of `ndk-build`?); I recovered the `actions` and `categories` elements for the intent filter to `Vec<String>` as well (side note: I forgot to update the documentation when I changed these items).

Further changes are probably needed.

Multiple activities & dex insertion test based on <https://github.com/wuwbobo2021/jni-min-helper/tree/perm>:

<details>
<summary>Click to expand</summary>

`Cargo.toml`:

```
[package]
name = "android-simple-test"
version = "0.1.0"
edition = "2021"
publish = false

[dependencies]
log = "0.4"
jni-min-helper = { path = "..", features = ["futures"] }
android-activity = { version = "0.6", features = ["native-activity"] }
android_logger = "0.14"

[build-dependencies]
android-build = "0.1.2"

[lib]
name = "android_simple_test"
crate-type = ["cdylib"]
path = "main.rs"

[package.metadata.android]
# android_manifest_file = "AndroidManifest.xml"
package = "com.example.android_simple_test"
build_targets = [ "aarch64-linux-android" ]

[package.metadata.android.sdk]
min_sdk_version = 16
target_sdk_version = 30

[[package.metadata.android.uses_permission]]
name = "android.permission.RECORD_AUDIO"

[[package.metadata.android.uses_permission]]
name = "android.permission.ACCESS_COARSE_LOCATION"

[[package.metadata.android.application.other_activity]]
name = "rust.jniminhelper.PermActivity"
```

`build.rs`:

```rust
use std::{env, fs, path::PathBuf};

use android_build::{Dexer, JavaBuild};

fn main() {
    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
    let src_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("java");
    let out_dir = env::var("CARGO_MANIFEST_DIR")
        .map(PathBuf::from)
        .unwrap()
        .join("target")
        .join(env::var("PROFILE").unwrap());

    if target_os == "android" {
        let sources = [
            src_dir.join("PermActivity.java"),
        ];
        let android_jar = android_build::android_jar(None);

        let out_cls_dir = out_dir.join("classes");
        if out_cls_dir.try_exists().unwrap() {
            fs::remove_dir_all(&out_cls_dir).unwrap();
        }
        fs::create_dir(&out_cls_dir).unwrap();

        let mut err_string = None;
        if android_jar.is_none() {
            err_string.replace("Failed to find android.jar.".to_string());
        } else if let Err(s) =
            compile_java_source(sources, [android_jar.clone().unwrap()], out_cls_dir.clone())
        {
            err_string.replace(s);
        } else if let Err(s) = build_dex_file(out_cls_dir.clone(), android_jar, [], out_dir.clone())
        {
            err_string.replace(s);
        };

        if let Some(s) = err_string {
            for line in s.lines() {
                println!("cargo::warning={line}");
            }
            panic!("Unable to build the dex file");
        }
    }
}

fn compile_java_source(
    source_paths: impl IntoIterator<Item = PathBuf>,
    class_paths: impl IntoIterator<Item = PathBuf>,
    output_dir: PathBuf,
) -> Result<(), String> {
    let mut java_build = JavaBuild::new();

    for java_src in source_paths {
        println!("cargo:rerun-if-changed={}", java_src.to_string_lossy());
        java_build.file(java_src);
    }

    for class_path in class_paths {
        println!("cargo:rerun-if-changed={}", class_path.to_string_lossy());
        java_build.class_path(class_path);
    }

    java_build.java_source_version(8).java_target_version(8);
    java_build.classes_out_dir(output_dir);

    // Execute the command
    let result = java_build
        .command()
        .map_err(|e| e.to_string())?
        .output()
        .map_err(|e| format!("Failed to execute javac: {e:?}"))?;
    if result.status.success() {
        Ok(())
    } else {
        Err(format!(
            "Java compilation failed: {}",
            String::from_utf8_lossy(&result.stderr)
        ))
    }
}

fn build_dex_file(
    compiled_classes_path: PathBuf,
    android_jar: Option<PathBuf>,
    jar_dependencies: impl IntoIterator<Item = PathBuf>,
    output_dir: PathBuf,
) -> Result<(), String> {
    let mut dexer = Dexer::new();
    if let Some(android_jar) = android_jar {
        dexer.android_jar(&android_jar);
    }
    let dependencies: Vec<_> = jar_dependencies.into_iter().collect();
    for dependency in dependencies.iter() {
        println!("cargo:rerun-if-changed={}", dependency.to_string_lossy());
        dexer.class_path(dependency);
    }
    dexer
        .android_min_api(20)
        .release(env::var("PROFILE").as_ref().map(|s| s.as_str()) == Ok("release"))
        .class_path(&compiled_classes_path)
        .no_desugaring(true)
        .out_dir(output_dir)
        .files(dependencies.iter())
        .collect_classes(&compiled_classes_path)
        .map_err(|e| e.to_string())?;

    // Execute the command
    let result = dexer
        .run()
        .map_err(|e| format!("Failed to execute d8.jar: {e:?}"))?;
    if result.success() {
        Ok(())
    } else {
        Err(format!("Dexer invocation failed: {result}"))
    }
}
```

`main.rs`:

```rust
use android_activity::{AndroidApp, MainEvent, PollEvent};
use jni_min_helper::*;
use std::time::Duration;
use log::info;

#[no_mangle]
fn android_main(app: AndroidApp) {
    android_logger::init_once(
        android_logger::Config::default()
            .with_max_level(log::LevelFilter::Info)
            .with_tag(android_app_name().as_bytes()),
    );

    info!("spawning...");
    std::thread::spawn(background_loop);

    let mut on_destroy = false;
    loop {
        app.poll_events(
            Some(Duration::from_secs(1)), // timeout
            |event| match event {
                PollEvent::Main(MainEvent::Start) => {
                    info!("Main Start.");
                }
                PollEvent::Main(MainEvent::Resume { loader: _, .. }) => {
                    info!("Main Resume.");
                }
                PollEvent::Main(MainEvent::Pause) => {
                    info!("Main Pause.");
                }
                PollEvent::Main(MainEvent::Stop) => {
                    info!("Main Stop.");
                }
                PollEvent::Main(MainEvent::Destroy) => {
                    info!("Main Destroy.");
                    on_destroy = true;
                }
                _ => (),
            },
        );
        if on_destroy {
            return;
        }
    }
}

fn background_loop() {
    // JniClassLoader::helper_loader().unwrap().replace_app_loader().unwrap();
    // info!("lodaer replaced...");
    let req = PermissionRequest::request("Test", [
        "android.permission.RECORD_AUDIO",
        "android.permission.ACCESS_COARSE_LOCATION",
    ])
    .unwrap();
    let Some(req) = req else {
        info!("permission request is not needed.");
        return;
    };
    info!("requesting permissions...");
    let result = req.wait();
    info!("{result:#?}");
}
```

</details>

Current problem of dex insertion: it's not appended to the APK when the application is compiled for the first time, but it's added while running `cargo apk build` for the second time.
