### PR TITLE
ndk-build: Make platform SDK parsing more robust and ignore minor suffix

### DIFF
--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -65,7 +65,7 @@ impl ApkConfig {
         self.build_dir.join(format!("{}.apk", self.apk_name))
     }
 
-    pub fn create_apk(&self) -> Result<UnalignedApk, NdkError> {
+    pub fn create_apk(&self) -> Result<UnalignedApk<'_>, NdkError> {
         std::fs::create_dir_all(&self.build_dir)?;
         self.manifest.write_to(&self.build_dir)?;
 

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -130,8 +130,25 @@ impl Ndk {
             .filter(|path| path.path().is_dir())
             .filter_map(|path| path.file_name().into_string().ok())
             .filter_map(|name| {
-                name.strip_prefix("android-")
-                    .and_then(|api| api.parse::<u32>().ok())
+                let mut version = name
+                    .strip_prefix("android-")
+                    .expect("Invalid platform name");
+                if let Some((_v, ext)) = version.split_once("-ext") {
+                    // version = v;
+                    let _ext_version = ext.parse::<u32>();
+                    eprintln!("Skipping platform SDK with extensions `{name}`");
+                    return None;
+                }
+                if let Some((v, minor_version)) = version.split_once('.') {
+                    let _minor_version = minor_version.parse::<u32>();
+                    eprintln!("Ignoring minor suffix on SDK version `{version}`");
+                    version = v;
+                }
+                Some(
+                    version
+                        .parse::<u32>()
+                        .expect("Invalid platform SDK version"),
+                )
             })
             .filter(|level| (min_platform_level..=max_platform_level).contains(level))
             .collect();
@@ -214,6 +231,8 @@ impl Ndk {
         let dir = self
             .sdk_path
             .join("platforms")
+            // TODO: If selected/used by Self::highest_supported_platform(),
+            // append the minor suffix
             .join(format!("android-{platform}"));
         if !dir.exists() {
             return Err(NdkError::PlatformNotFound(platform));


### PR DESCRIPTION
Fixes #74

The minor suffix of an SDK version is not something that can be targeted or conveyed in an Android app; ignore it for now as we only use this to determine the highest API level to target.

However `fn platform_dir()` independently tries to reconstruct this path based on an API target and now has no idea to append `.1` if only `android-36.1` happens to be installed for instance.  This should be brought back in sync.
