### PR TITLE
Allow running Cargo binaries directly

### DIFF
--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -143,6 +143,7 @@ impl<'a> ApkBuilder<'a> {
                 *target,
                 self.min_sdk_version(),
                 self.cmd.target_dir(),
+                self.manifest.hacky_bins,
             )?;
             cargo.arg("check");
             if self.cmd.target().is_none() {
@@ -220,13 +221,29 @@ impl<'a> ApkBuilder<'a> {
         for target in &self.build_targets {
             let triple = target.rust_triple();
             let build_dir = self.cmd.build_dir(Some(triple));
-            let artifact = self.cmd.artifact(artifact, Some(triple), CrateType::Cdylib);
+            let lib = self.cmd.artifact(artifact, Some(triple), CrateType::Cdylib);
+
+            if self.manifest.hacky_bins {
+                let actual_bin = self.cmd.artifact(artifact, Some(triple), CrateType::Bin);
+                #[cfg(unix)]
+                {
+                    if let Err(err) = std::fs::remove_file(&lib) {
+                        if err.kind() != std::io::ErrorKind::NotFound {
+                            return Err(err.into());
+                        }
+                    }
+                    std::os::unix::fs::symlink(actual_bin, &lib)?;
+                }
+                #[cfg(not(unix))]
+                std::fs::copy(actual_bin, &lib)?;
+            }
 
             let mut cargo = cargo_ndk(
                 &self.ndk,
                 *target,
                 self.min_sdk_version(),
                 self.cmd.target_dir(),
+                self.manifest.hacky_bins,
             )?;
             cargo.arg("build");
             if self.cmd.target().is_none() {
@@ -247,7 +264,7 @@ impl<'a> ApkBuilder<'a> {
                 .map(|path| path.as_path())
                 .collect::<Vec<_>>();
 
-            apk.add_lib_recursively(&artifact, *target, libs_search_paths.as_slice())?;
+            apk.add_lib_recursively(&lib, *target, libs_search_paths.as_slice())?;
 
             if let Some(runtime_libs) = &runtime_libs {
                 apk.add_runtime_libs(runtime_libs, *target, libs_search_paths.as_slice())?;
@@ -347,6 +364,7 @@ impl<'a> ApkBuilder<'a> {
                 *target,
                 self.min_sdk_version(),
                 self.cmd.target_dir(),
+                self.manifest.hacky_bins,
             )?;
             cargo.arg(cargo_cmd);
             self.cmd.args().apply(&mut cargo);

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -27,6 +27,7 @@ pub(crate) struct Manifest {
     pub(crate) signing: HashMap<String, Signing>,
     pub(crate) reverse_port_forward: HashMap<String, String>,
     pub(crate) strip: StripConfig,
+    pub(crate) hacky_bins: bool,
 }
 
 impl Manifest {
@@ -53,6 +54,7 @@ impl Manifest {
             signing: metadata.signing,
             reverse_port_forward: metadata.reverse_port_forward,
             strip: metadata.strip,
+            hacky_bins: metadata.hacky_bins,
         })
     }
 }
@@ -111,6 +113,8 @@ struct AndroidMetadata {
     reverse_port_forward: HashMap<String, String>,
     #[serde(default)]
     strip: StripConfig,
+    #[serde(default)]
+    hacky_bins: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -9,6 +9,7 @@ pub fn cargo_ndk(
     target: Target,
     sdk_version: u32,
     target_dir: impl AsRef<Path>,
+    hacky_bins: bool,
 ) -> Result<Command, NdkError> {
     let triple = target.rust_triple();
     let clang_target = format!("--target={}{}", target.ndk_llvm_triple(), sdk_version);
@@ -103,6 +104,13 @@ pub fn cargo_ndk(
                 .to_str()
                 .expect("Target dir must be valid UTF-8"),
         );
+    }
+
+    if hacky_bins {
+        rustflags.push_str(SEP);
+        rustflags.push_str("-Clink-arg=-shared");
+        rustflags.push_str(SEP);
+        rustflags.push_str("-Clink-arg=-no-pie");
     }
 
     cargo.env("CARGO_ENCODED_RUSTFLAGS", rustflags);


### PR DESCRIPTION
I strongly dislike the extra `*_android.rs` example files that we need in `softbuffer`. These are required because we have to tell Cargo to generate a `cdylib` with `crate-type = ["cdylib"]` for each example that runs on Android.

Instead of that, we can pass `-Clink-arg=-shared -Clink-arg=-no-pie` to `rustc`, together with `#![no_main]`, which tricks the linker into thinking that the `bin` / executable target is actually a dynamic library.

This means that all a user of `winit` has to do is:
```rust
#![cfg_attr(target_os = "android", no_main)]
use winit::event_loop::EventLoop;

#[cfg(target_os = "android")]
#[no_mangle]
fn android_main(app: winit::platform::android::activity::AndroidApp) {
    use winit::platform::android::EventLoopBuilderExtAndroid;
    let mut builder = EventLoop::builder();
    builder.with_android_app(app);
    entrypoint(builder.build().unwrap())
}

#[cfg(not(target_os = "android"))]
fn main() {
    entrypoint(EventLoop::new().unwrap())
}

fn entrypoint(event_loop: EventLoop<()>) {
    todo!()
}
```

Which, to be fair, is still a mouthful, but it's better, and it could be reduced with macros. Have a look at [this branch](https://github.com/rust-windowing/softbuffer/compare/master...madsmtm/cargo-apk-hacky-bins) for trying it out in `softbuffer`.

Opened as a draft to show you that it's possible. I haven't polished it yet, but I'd like to know if a hack like this is something you'd be interested in before proceeding.