### PR TITLE
Set `--crate-type cdylib` from the cmdline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea/

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -29,23 +29,7 @@ $ cargo install --path cargo-apk/
 
 ## Crate configuration
 
-Android and thus `cargo-apk` require the [Cargo Target] to be a Shared Library, corresponding to Rust's `cdylib` `crate-type`.  For the sole library in a crate, configure this as follows in `Cargo.toml`:
-
-```toml
-[lib]
-# Optionally supports a different library location using `path = "..."`
-crate-type = ["cdylib"]
-```
-
-Example targets must be identified by their `name` or `path` in the list of `example`s:
-
-```toml
-[[example]]
-name = "example_name" # Matching the filename in `examples/example_name.rs`, unless specified otherwise with `path = "..."`
-crate-type = ["cdylib"]
-```
-
-[Cargo Target]: https://doc.rust-lang.org/cargo/reference/cargo-targets.html
+Crate specific configuration is no longer required, you can just build it out of the box. Old configurations explicitly declaring the `crate-type` can be removed. 
 
 ## Commands
 
@@ -57,7 +41,7 @@ Invoke `cargo apk help` for a more detailed overview of all available commands a
 
 ### Target selection
 
-Like `cargo`, the above subcommands from `cargo apk` support selecting the target to build and/or run using `--package`/`-p` (which picks the library target inside the crate) or `--example`, as long as the Cargo Target is a `cdylib` as described above.
+Like `cargo`, the above subcommands from `cargo apk` support selecting the target to build and/or run using `--package`/`-p` (which picks the library target inside the crate) or `--example`.
 
 ## Manifest
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -228,7 +228,8 @@ impl<'a> ApkBuilder<'a> {
                 self.min_sdk_version(),
                 self.cmd.target_dir(),
             )?;
-            cargo.arg("build");
+            cargo.arg("rustc");
+            cargo.args(["--crate-type", "cdylib"]);
             if self.cmd.target().is_none() {
                 cargo.arg("--target").arg(triple);
             }

--- a/ndk-examples/Cargo.toml
+++ b/ndk-examples/Cargo.toml
@@ -12,15 +12,3 @@ ndk = { version = "0.9", features = ["api-level-23"] }
 ndk-context = "0.1.1"
 android_logger = "0.15"
 android-activity = { version = "0.6", features = ["native-activity"] }
-
-[[example]]
-name = "hello_world"
-crate-type = ["cdylib"]
-
-[[example]]
-name = "jni_audio"
-crate-type = ["cdylib"]
-
-[[example]]
-name = "looper"
-crate-type = ["cdylib"]


### PR DESCRIPTION
Instead of `cargo build`, you can use `cargo rustc --crate-type dylib` to specify the crate type you want the *target crate* (not it's dependencies) to be compiled to. All "main apk" crates **can** (but don't have to) remove the previously required declaration in `Cargo.toml` below:
```toml
[lib]
crate-type = ["dylib"]
```

This is entirely untested due to me not having the Android SDK installed, hoping that github actions will test it properly. 

Also see [rust-gpu's PR](https://github.com/Rust-GPU/rust-gpu/pull/477) doing the exact same thing, where our [Android build](https://github.com/Rust-GPU/rust-gpu/actions/runs/19961760127/job/57243644072?pr=477) failed since I removed the explicit crate type everywhere. 